### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Key Usage Finder can be run in `--verbose` mode which will output more details o
 * Service Name, Resource Type, ARN (or resource identifier), and encryption context.
 
 ```
-python3 finders-keypers.py --keyarn arn:aws:kms:us-east-1:123412341234:key/aaaaaaaa-aaaa-1111-aaaa-aaaa1111aaaa --verbose                       
+python3 finders_keypers.py --keyarn arn:aws:kms:us-east-1:123412341234:key/aaaaaaaa-aaaa-1111-aaaa-aaaa1111aaaa --verbose                       
 
 Total Number of Resources encrypted with KMS Key Provided: 6
 {'Service': 'Glue', 'Resource': 'Data Catalog', 'ARN': 'ARN', 'Context': 'Connection Password Encryption'}

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Blog Post: [https://www.fogsecurity.io/blog/introducing-finders-keypers-a-tool-t
 ### Running
 
 ```
- python3 finders-keypers.py --keyarn arn:aws:kms:us-east-1:123412341234:key/aaaaaaaa-aaaa-1111-aaaa-aaaa1111aaaa 
+ python3 finders_keypers.py --keyarn arn:aws:kms:us-east-1:123412341234:key/aaaaaaaa-aaaa-1111-aaaa-aaaa1111aaaa 
 
 ```
 
@@ -34,7 +34,7 @@ The tool will scan resources for KMS Key Usage and output the following:
 * ARN, resource identifier, or description (if ARN is unavailable)
 
 ```
-python3 finders-keypers.py --keyarn arn:aws:kms:us-east-1:123412341234:key/aaaaaaaa-aaaa-1111-aaaa-aaaa1111aaaa                   
+python3 finders_keypers.py --keyarn arn:aws:kms:us-east-1:123412341234:key/aaaaaaaa-aaaa-1111-aaaa-aaaa1111aaaa                   
 
 Total Number of Resources encrypted with KMS Key Provided: 5
 example-bucket-finderskeypers


### PR DESCRIPTION
Examples of running Finders Keypers had hyphens and not underscores for the file.