### PR TITLE
Add Output to save run data

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ Total Number of Resources encrypted with KMS Key Provided: 6
 
 ```
 
+### Saving Data
+
+Finders Keypers now has an option to save run data to a json file locally.  This can be done via the optional `--output` argument.  To save, use the `--output` argument followed by the file name.  Results are stored with metadata from the run.
+
+```
+ python3 finders_keypers.py --keyarn arn:aws:kms:us-east-1:123412341234:key/aaaaaaaa-aaaa-1111-aaaa-aaaa1111aaaa --output finders_keypers_sample_run.json
+```
+
 ### Requirements and Installation
 
 * Python & Boto3

--- a/finders_keypers.py
+++ b/finders_keypers.py
@@ -4,6 +4,7 @@ import argparse
 import boto3
 import botocore
 import json
+from datetime import datetime
 from modules.service_key_finder import find_kms_key_usage
 
 '''
@@ -56,8 +57,17 @@ try:
             key_index = key_index + 1
 
     if args.output:
+        output = {}
+
+        output['metadata'] = {
+                'input_key': input_key_arn,
+                'timestamp': datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        }
+
+        output['results'] = key_resources
+
         with open(args.output, 'w') as f:
-            json.dump(key_resources, f, indent=4)
+            json.dump(output, f, indent=4)
 
 except Exception as e:
     print(f"Error while running Key Usage Finder: {e}")

--- a/finders_keypers.py
+++ b/finders_keypers.py
@@ -3,6 +3,7 @@ import sys
 import argparse
 import boto3
 import botocore
+import json
 from modules.service_key_finder import find_kms_key_usage
 
 '''
@@ -22,6 +23,7 @@ def kms_key_arn (input_key_arn):
 parser.add_argument("--keyarn", type=kms_key_arn, required=True)
 parser.add_argument("--profile")
 parser.add_argument("--verbose", action='store_true')
+parser.add_argument("--output", help='Output file name')
 
 args = parser.parse_args()
 
@@ -52,6 +54,10 @@ try:
         for item in key_resources:
             print (key_resources[key_index]['arn'])
             key_index = key_index + 1
+
+    if args.output:
+        with open(args.output, 'w') as f:
+            json.dump(key_resources, f, indent=4)
 
 except Exception as e:
     print(f"Error while running Key Usage Finder: {e}")


### PR DESCRIPTION
This adds the ability to save Finders Keypers output as a json file locally.

This is done via the optional `--output` flag.