### PR TITLE
Add Support for S3 Tables (within Table Buckets)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Finders Keypers now has an option to save run data to a json file locally.  This
 * AWS Credentials and Access.
 
 For IAM Permissions, Finders Keypers does not require non-read permissions (such as create, delete, or modification).  We recommend least privilege permissions.  Permissions necessary can be found in the [iam/](iam/) folder.  The AWS managed - job function `ReadOnlyAccess` policy can be used with Finders Keypers.  For a complete scan, Finders Keypers uses permissions for each service you want to scan.  In some cases, the `SecurityAudit` policy could suffice, but we recommend starting with `ReadOnlyAccess` to ensure complete coverage. The `ViewOnlyAccess` policy provided by AWS is limited and will not work with Finders Keypers.
-Note: Currently, S3 Table Bucket permissions are not in `ReadOnlyAccess`.  See IAM folder for necessary permissions.
+Note: Currently, S3 Tables permissions are not in `ReadOnlyAccess`.  See IAM folder for necessary permissions.
 
 We recommend also checking KMS key policies, organizational policies such as RCPs and SCPs if there are access issues and to ensure Finders Keypers has access.  
 
@@ -97,7 +97,7 @@ For AWS Credentials and setting up the AWS CLI, see AWS CLI documentation on [cr
 
 ### Supported Services:
 
-Currently supports 22 AWS Services and 29 different resource types.
+Currently supports 22 AWS Services and 30 different resource types.
 
 #### AWS Compute:
 
@@ -140,6 +140,7 @@ Currently supports 22 AWS Services and 29 different resource types.
 ### Supported Resources:
 - S3 Buckets
 - S3 Table Buckets
+- S3 Tables
 - EFS File Systems
 - Aurora Instances
 - Aurora Clusters

--- a/iam/finderskeypers_ref_iam_policy.json
+++ b/iam/finderskeypers_ref_iam_policy.json
@@ -21,6 +21,8 @@
                 "s3:GetBucketLocation",
                 "s3tables:ListTableBuckets",
                 "s3tables:GetTableBucketEncryption",
+                "s3tables:ListTables",
+                "s3tables:GetTableEncryption",
                 "ec2:DescribeVolumes",
                 "qldb:ListLedgers",
                 "qldb:DescribeLedger",


### PR DESCRIPTION
Add Support for S3 Tables (within Table Buckets).  Table Buckets has been added already.  This is for S3 Tables.